### PR TITLE
fix: correct spelling of onBoardingAuthMiddleware in middleware and route files

### DIFF
--- a/app/middlewares/on-boarding-auth-middleware.ts
+++ b/app/middlewares/on-boarding-auth-middleware.ts
@@ -6,7 +6,7 @@ import {
 import { requireAuth } from '~/services/auth'
 import { userContext } from './user-context'
 
-export const onBordingAuthMiddleware: MiddlewareFunction = async ({
+export const onBoardingAuthMiddleware: MiddlewareFunction = async ({
   request,
   context,
 }) => {

--- a/app/routes/welcome+/_layout/route.ts
+++ b/app/routes/welcome+/_layout/route.ts
@@ -1,4 +1,4 @@
-import { onBordingAuthMiddleware } from '~/middlewares/on-boarding-auth-middleware'
+import { onBoardingAuthMiddleware } from '~/middlewares/on-boarding-auth-middleware'
 
 // Middleware を設定
-export const unstable_clientMiddleware = [onBordingAuthMiddleware]
+export const unstable_clientMiddleware = [onBoardingAuthMiddleware]


### PR DESCRIPTION
This pull request includes a couple of changes to correct a typo in the middleware name within the `on-boarding-auth-middleware.ts` file and its usage in the `welcome+/_layout/route.ts` file.

Corrections to middleware name:

* [`app/middlewares/on-boarding-auth-middleware.ts`](diffhunk://#diff-a16e1753d7c44cd10a571662c9bd77ec40536b79a4a2b646c48bd039b7e600d2L9-R9): Renamed `onBordingAuthMiddleware` to `onBoardingAuthMiddleware`.
* [`app/routes/welcome+/_layout/route.ts`](diffhunk://#diff-56f2c1d9453f76ccdb69aace19cf36efffc64e01c36ee16425604e8edc516947L1-R4): Updated the import and usage of `onBoardingAuthMiddleware` to reflect the corrected name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Standardized naming conventions in the authentication and onboarding processes for improved clarity and consistency without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->